### PR TITLE
Miscellaneous minor corrections

### DIFF
--- a/exercises/conversions.gie
+++ b/exercises/conversions.gie
@@ -1,5 +1,3 @@
-<gie>
-
 ###############################################################################
 
                                 Coordinate Conversions
@@ -23,6 +21,7 @@ See [0] for a list of all conversions available in PROJ.
 [0] https://proj4.org/operations/conversions/index.html
 
 ###############################################################################
+<gie>
 
 
 1. Unit conversion from meters to feet
@@ -38,7 +37,7 @@ Hints:
 
     - You can use `proj -lu` to learn which units is supported by PROJ.
 
-    - Note that the horizontal, vertical and temporal parts area treated
+    - Note that the horizontal, vertical and temporal parts are treated
       separately by the unit convert operator.
 
 -------------------------------------------------------------------------------
@@ -78,8 +77,8 @@ Hints:
 operation   <your answer here>
 tolerance   1 mm
 
-accept      140.0   75.0    # somewhere in Siberia
-expect      75.0    140.0
+accept      140.0     75.0    # somewhere in Siberia
+expect       75.0    140.0
 
 -------------------------------------------------------------------------------
 
@@ -101,7 +100,9 @@ Hints:
       https://proj4.org/operations/conversions/cart.html
 
     - Remember that `proj -le` returns a list of available ellipsoid models
-
+	
+	- Remember that the Hayford ellipsoid is known under a number of other
+	  names - most of them including the term "international".
 
 -------------------------------------------------------------------------------
 
@@ -112,7 +113,6 @@ accept      24.745          59.437          0  # Talinn, Estonia
 expect      2952883.7000    1360985.5908    5468966.6589
 
 -------------------------------------------------------------------------------
-
 
 
 </gie>

--- a/exercises/ellipsoids.gie
+++ b/exercises/ellipsoids.gie
@@ -6,8 +6,8 @@ In this exercise we will introduce some of the many ways one can specify the
 ellipsoid model used in projections and transformations.
 
 We will be using the Mercator projection to illustrate the different ellipsoid
-settings, but note thet the same parameter settings can be used for setting
-the ellipsoid used for all PROJ projections and most PROJ transformations.
+settings, but note that the same parameter settings can be used for setting
+the ellipsoid used for most PROJ projections and transformations.
 
 ###############################################################################
 <gie>

--- a/exercises/ellipsoids.gie
+++ b/exercises/ellipsoids.gie
@@ -1,18 +1,16 @@
-<gie>
-
 ###############################################################################
 
                        Specifying ellipsoid models
 
-In this exercise we will introduce how to set up the ellipsoid model used in
-projections and transformations. There are several ways to specify an ellipsoid
-model which we will familiarize ourselves with in this set of exercises.
+In this exercise we will introduce some of the many ways one can specify the
+ellipsoid model used in projections and transformations.
 
 We will be using the Mercator projection to illustrate the different ellipsoid
-settings. Note that ALL for all projections and some transformations the
-ellipsoid can be changed using the same parameter names.
+settings, but note thet the same parameter settings can be used for setting
+the ellipsoid used for all PROJ projections and most PROJ transformations.
 
 ###############################################################################
+<gie>
 
 
 1. Use a sphere of radius 1 as the ellipsoid model:
@@ -28,6 +26,7 @@ tolerance   1 cm
 
 accept      24.745          59.437          # Talinn
 expect      0.4319          1.2975
+
 -------------------------------------------------------------------------------
 
 
@@ -46,6 +45,7 @@ tolerance   1 cm
 
 accept      24.745          59.437          # Talinn
 expect      2754709.2020    8238786.4803
+
 -------------------------------------------------------------------------------
 
 
@@ -55,6 +55,7 @@ expect      2754709.2020    8238786.4803
 Hints:
 
   * Find the parameters in the list returned by `proj -le`
+
 -------------------------------------------------------------------------------
 
 operation   +proj=merc  <your answer here>
@@ -62,6 +63,7 @@ tolerance   1 cm
 
 accept      24.745          59.437          # Talinn
 expect      2754709.2020    8238786.4803
+
 -------------------------------------------------------------------------------
 
 
@@ -73,8 +75,7 @@ tolerance   1 cm
 
 accept      24.745          59.437          # Talinn
 expect      2754630.7723    8238298.4968
+
 -------------------------------------------------------------------------------
-
-
 
 </gie>

--- a/exercises/gridshift.gie
+++ b/exercises/gridshift.gie
@@ -1,23 +1,23 @@
-<gie>
 ###############################################################################
 
                                 Grid shifting
 
-Some times it is simpler to define a transformation as a gridded model of
-displacements instead of coming up with a mathematical description of said
-displacements. This approach is used by many local geodetic authorities and the
-method is becoming more and more popular since we are not limited by lack of
-disk space to the same degree as in the past. Gridded models of displacements
-offer the ability to make local adjustments that are not possible with e.g. a
-Helmert transformation. This fact is especially leveraged in transformations of
-heights since the geoid is too bumpy to retain enough detail with a simple
-mathematical definition.
+Sometimes it is simpler to define a transformation as a gridded model of
+displacements rather than a mathematical model. This approach, pioneered
+by the US National Geodetic Survey in their 1980s era transformation from
+the old NAD27 datum to the (back then) new NAD83, has become increasingly
+popular as disk space and CPU cycles have gotten cheaper.
+
+Gridded models of displacements offer the ability to make local adjustments
+that are not possible with e.g. a Helmert transformation. This fact is
+especially leveraged in transformations of heights since the geoid is too
+bumpy to retain enough detail with a simple mathematical definition.
 
 The main problem with grid shifting is availability of the grids needed for a
 given transformation. The PROJ package requires that the proj-datumgrid package
 [0] is installed alongside it. Additionally, the PROJ project offers regional
-grid package which include many of the grids freely available in those regions
-[1][2][3][4].
+grid packages [1][2][3][4], each including most of the freely redistributable
+grids available from geodetic authorities in those regions.
 
 [0] https://proj4.org/resource_files.html
 [1] https://github.com/OSGeo/proj-datumgrid/tree/master/europe#proj-datumgrid-europe
@@ -26,6 +26,7 @@ grid package which include many of the grids freely available in those regions
 [4] https://github.com/OSGeo/proj-datumgrid/tree/master/world#proj-datumgrid-world
 
 ###############################################################################
+<gie>
 
 
 1. Horizontal gridshifting
@@ -62,9 +63,9 @@ expect      12.9983317082   51.9986488216   0.0
 
 2. Vertical gridshifting
 -------------------------------------------------------------------------------
-The most common use cases of vertical grid shifts is conversion from
-ellipsoidal heights to physical heights, which in most cases is equvialent to
-applying an offset from a geoid model. Which is exactly what we will do in this
+The most common use case for vertical grid shifts is conversion from
+ellipsoidal heights to physical heights. In most cases this is equvialent to
+applying an offset from a geoid model, which is exactly what we will do in this
 exercise.
 
 Set up an operation that transforms ellipsoidal heights to physical heights
@@ -87,7 +88,5 @@ accept      13.0            52.0          100.0
 expect      13.0            52.0           58.1917
 
 -------------------------------------------------------------------------------
-
-
 
 </gie>

--- a/exercises/helmert.gie
+++ b/exercises/helmert.gie
@@ -1,5 +1,3 @@
-<gie>
-
 ###############################################################################
 
                        The Helmert transformation
@@ -20,6 +18,7 @@ transformation setup.
 [1] https://proj4.org/operations/transformations/helmert.html
 
 ###############################################################################
+<gie>
 
 
 1. Simple coordinate translation
@@ -30,7 +29,7 @@ the x-, y- and z-components of the coordinate. This is rarely a good fit for
 large areas but locally a 3 parameter Helmert shift can be very effective. Even
 though the 3 parameter translation doesn't fit particularly well in large areas
 of use it is still commonly used between legacy and modern systems. In this
-exercise we'll be using a transformation between ED50 in Italy (Sardinia) and
+exercise we will use a transformation between ED50 in Italy (Sardinia) and
 WGS84.
 
 
@@ -82,12 +81,12 @@ Hints:
     - Remember to specify the rotation convention with +convention
 
 -------------------------------------------------------------------------------
-#operation   <your answer here>
+
+operation   <your answer here>
 tolerance   1 m
 
 accept      3496723.5936    743251.5442  5264442.2361
 expect      3496639.7297    743156.3657  5264324.9341
-
 
 -------------------------------------------------------------------------------
 
@@ -166,6 +165,5 @@ tolerance   1 mm
 accept      2952736.3768   1360917.6894  5468849.5615       2019.5
 expect      2952736.3744   1360917.6871  5468849.5586       2019.5
 -------------------------------------------------------------------------------
-
 
 </gie>

--- a/exercises/projections1.gie
+++ b/exercises/projections1.gie
@@ -1,5 +1,3 @@
-<gie>
-
 ###############################################################################
 
                                 The UTM Projection
@@ -9,6 +7,7 @@ We will investigate a few aspects of the UTM projection, as well as learn how
 to use a different ellipsoid than the default (GRS80).
 
 ###############################################################################
+<gie>
 
 
 1. Set up a UTM projection for use in Estonia.
@@ -24,6 +23,7 @@ tolerance   1 cm
 
 accept      24.745          59.437       # Talinn, Estonia
 expect      372106.37       6590881.40
+
 -------------------------------------------------------------------------------
 
 
@@ -42,6 +42,7 @@ tolerance   1 cm
 
 accept      174.740        -36.841      # Auckland, New Zealand
 expect      298481.34       5920382.04
+
 -------------------------------------------------------------------------------
 
 
@@ -58,11 +59,13 @@ Hints:
         proj -le
 
 -------------------------------------------------------------------------------
+
 operation   <your answer here>
 tolerance   1 cm
 
 accept      24.745          59.437       # Talinn, Estonia
 expect      372099.99       6591034.35
+
 -------------------------------------------------------------------------------
 
 </gie>

--- a/exercises/projections2.gie
+++ b/exercises/projections2.gie
@@ -59,6 +59,7 @@ expect      1351962.01          298663.54
 
 accept      24.745              59.437  # Tallinn
 expect      1371811.19          218598.22
+
 -------------------------------------------------------------------------------
 
 
@@ -92,12 +93,15 @@ Hints:
     - Look for the lines displaying the meridian and parallel scale.
     - Consult the LCC documentation to find out how to set the scaling factor.
     - Scaling factors usually deviates from unity by the order of 1e-3 to 1e-5
+
 ------------------------------------------------------------------------------
+
 operation   <your answer here>
 tolerance   1 um
 
 accept      24.745              59.437
 expect      1371783.759883408	218593.850591891
+
 ------------------------------------------------------------------------------
 
 
@@ -109,12 +113,15 @@ Hints:
 
     - Approximate location of Helsinki:     60.171N 24.938E
     - Approximate location of Talinn:       59.437N 24.745E
+
 -------------------------------------------------------------------------------
+
 operation   <your answer here>
 tolerance   1 cm
 
 accept      24.8                59.8
 expect      1359907.80          8024082.260
+
 ------------------------------------------------------------------------------
 
 
@@ -132,11 +139,13 @@ Hints:
     - The LCC documentation explains how to change the projection center
 
 ------------------------------------------------------------------------------
+
 operation   <your answer here>
 tolerance   1 cm
 
 accept      24.8            59.8
 expect       0.0             0.0
+
 ------------------------------------------------------------------------------
 
 
@@ -150,12 +159,15 @@ expect       0.0             0.0
 Hints:
 
     - The LCC documentation explains how to set false easting/northing
+
 ------------------------------------------------------------------------------
+
 operation   <your answer here>
 tolerance   1 cm
 
 accept      24.8            59.8
 expect      1000000.00      1000000.00
+
 ------------------------------------------------------------------------------
 
 </gie>

--- a/exercises/projections3.gie
+++ b/exercises/projections3.gie
@@ -1,5 +1,3 @@
-<gie>
-
 ###############################################################################
 
                        The Transverse Mercator projection
@@ -12,6 +10,7 @@ Mercator implementations available in PROJ and when one should be used in
 favour of the other.
 
 ###############################################################################
+<gie>
 
 
 1. Set up a Transverse Mercator projection using the default parameters.
@@ -20,6 +19,7 @@ Hints:
 
   * Consult the documentation at
     https://proj4.org/operations/projections/tmerc.html
+
 -------------------------------------------------------------------------------
 
 operation   <your answer here>
@@ -27,7 +27,9 @@ tolerance   1 mm
 
 accept      24.745          56.437       # Talinn, Estonia
 expect      1506742.2481    6535299.3398
+
 -------------------------------------------------------------------------------
+
 
 2. Use the Transverse Mercator to model the UTM projection
 -------------------------------------------------------------------------------
@@ -53,11 +55,14 @@ Hints:
       * https://proj4.org/operations/projections/utm.html
       * https://en.wikipedia.org/wiki/Universal_Transverse_Mercator_coordinate_system
 
+-------------------------------------------------------------------------------
+
 operation  <your answer here>
 tolerance   1 mm
 
 accept      24.745          56.437       # Talinn, Estonia
 expect      360965.5942     6256998.5609
+
 -------------------------------------------------------------------------------
 
 
@@ -89,8 +94,8 @@ Hints:
 
     - gie accepts most common SI unit prefixes to the meter when specifying
       the tolerance, e.g. km, m, dm, cm, mm, um, nm.
--------------------------------------------------------------------------------
 
+-------------------------------------------------------------------------------
 
 * 3a. As a baseline, determine the roundtrip accuracy of the default algorirthm
       using UTM zone 22:
@@ -153,6 +158,8 @@ tolerance   <your answer here>
 
 accept      -20.0   74      # Daneborg, Greenland
 roundtrip   1000
+
+-------------------------------------------------------------------------------
 
 
 </gie>


### PR DESCRIPTION
A few cases of spelling errors - apparently mostly introduced by an
over-eager auto correct function.

Use sometimes rather than some times, when the meaning is "occasionally".

Consistently leave the introductory section out of the `<gie>/</gie>` block
(best practice - to allow any gie command given as example in the intro,
without gie interpreting it as an actual command).

Remove some superfluous whitespace, and a stray '#'.

Add some additional whitespace for consistency

Improve (?) the wording a few places